### PR TITLE
Removes green LED continuous light

### DIFF
--- a/variants/t114/variant.h
+++ b/variants/t114/variant.h
@@ -72,7 +72,7 @@
 #define LED_BLUE                (-1)            // No blue led, prevents Bluefruit flashing the green LED during advertising
 #define LED_PIN                 LED_BUILTIN
 
-#define LED_STATE_ON            HIGH
+#define LED_STATE_ON            LOW
 
 #define PIN_NEOPIXEL            (14)
 #define NEOPIXEL_NUM            (2)


### PR DESCRIPTION
Generally, the green LED is on most time. With this small change, the LED is mostly off, expect whiles sending and receiving messages adverts and telemetry data.